### PR TITLE
Added support for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 Gemfile.lock
+.DS_store

--- a/lib/keen-cli/cli.rb
+++ b/lib/keen-cli/cli.rb
@@ -11,6 +11,8 @@ require 'keen-cli/projects'
 require 'keen-cli/events'
 require 'keen-cli/queries'
 
+require 'keen-cli/plugins'
+
 module KeenCli
 
   class CLI < Thor

--- a/lib/keen-cli/plugins.rb
+++ b/lib/keen-cli/plugins.rb
@@ -1,0 +1,43 @@
+module KeenCli
+
+  class CLI < Thor
+
+    desc 'plugins:install', 'Install a plugin'
+    map 'plugins:install' => :plugins_install
+
+    def plugins_install(name)
+      begin
+        puts "Installing keen-cli-#{name} plugin"
+        gem "keen-cli-#{name}"
+        true
+      rescue LoadError
+        %x("gem install keen-cli-#{name}")
+        unless $? == 0
+          false
+        else
+          true
+        end
+      end
+    end
+    
+    desc 'plugins:remove', 'Remove a plugin'
+    map 'plugins:remove' => :plugins_remove
+
+    def plugins_remove(name)
+      begin
+        puts "Removing keen-cli-#{name} plugin"
+        gem "keen-cli-#{name}"
+        true
+      rescue LoadError
+        %x("gem uninstall keen-cli-#{name}")
+        unless $? == 0
+          false
+        else
+          true
+        end
+      end
+    end
+    
+  end
+
+end

--- a/lib/keen-cli/plugins.rb
+++ b/lib/keen-cli/plugins.rb
@@ -38,6 +38,26 @@ module KeenCli
       end
     end
     
+    # browse for installed plugins
+	  begin
+	    name = nil  # plugin name
+	    plugins = Gem::Specification.select{ |g| g.name.downcase.include? "keen-cli-"} # keen-cli- prefix is used for plugins
+	    plugins.each {|plugin|
+	      name = plugin.name.gsub(/keen-cli-/,'')
+	      
+	      # load the plugin gem
+	      require "keen-cli-#{name}"
+	      command = Object.const_get("KeenCli::" << name.capitalize)
+	      
+	      # attach subcommand
+  	    desc name, "Manage the #{name} plugin"
+  	    subcommand name, command
+	    }
+    rescue LoadError	    
+      # gem isn't installed
+      puts "Could not find plugin \"#{name}\""
+	  end
+    
   end
 
 end

--- a/spec/keen-cli/plugins_spec.rb
+++ b/spec/keen-cli/plugins_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe KeenCli::CLI do
+
+  def start(str=nil)
+    KeenCli::CLI.start(str ? str.split(" ") : [])
+  end
+  
+  describe 'install' do
+    it 'fails if no plugin is specified' do
+      _, options = start "plugins:install"
+      expect(_).to be_nil
+    end
+    
+    it 'fails if plugin doesn\'t exist' do
+      _, options = start "plugins:install undefined"
+      expect(_).to be false
+    end
+  end
+  
+  describe 'remove' do
+    it 'fails if no plugin is specified' do
+      _, options = start "plugins:remove"
+      expect(_).to be_nil
+    end
+    
+    it 'fails if plugin doesn\'t exist' do
+      _, options = start "plugins:remove undefined"
+      expect(_).to be false
+    end
+  end
+  
+end


### PR DESCRIPTION
- Added support for plugins via the `plugins:install` and `plugins:remove` commands.
- Supports plugins developed as gems utilizing the `keen-cli-#{name}` naming convention.
- Leaving plugin commands undocumented until development is completed for the first plugin.
