### PR TITLE
Automatically remove keen.id and keen.created_at from events to be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ $ keen events:add --file events.json
 $ keen events:add --file events.csv --csv
 ```
 
+Notes:
+
++ `keen.id` and `keen.created_at` properties are automatically removed from events before uploading. The API generates these properties and it will refuse them from clients. The automatic removal makes export & re-import scenarios easier.
+
 ##### Queries
 
 `queries:run` - Runs a query and prints the result

--- a/lib/keen-cli/batch_processor.rb
+++ b/lib/keen-cli/batch_processor.rb
@@ -86,6 +86,13 @@ module KeenCli
     private
 
     def add_event_and_flush_if_necessary(event)
+
+      # remove keen.id and keen.created_at
+      if keen = event["keen"]
+        keen.delete("id")
+        keen.delete("created_at")
+      end
+
       self.events.push(event)
       self.size += 1
       self.total_size += 1

--- a/spec/keen-cli/batch_processor_spec.rb
+++ b/spec/keen-cli/batch_processor_spec.rb
@@ -156,6 +156,16 @@ module KeenCli
         expect(batch_processor.events).to be_empty
       end
 
+      it 'removes the keen.id property' do
+        batch_processor.add('{ "keen": { "id" : "abcde" } }')
+        expect(batch_processor.events.first).to eq({ "keen" => {} })
+      end
+
+      it 'removes the keen.created_at property' do
+        batch_processor.add('{ "keen": { "created_at" : "2014-01-01T00:00:00Z" } }')
+        expect(batch_processor.events.first).to eq({ "keen" => {} })
+      end
+
     end
 
     describe 'flush' do


### PR DESCRIPTION
Makes export / re-import easier
