### PR TITLE
add collection name to CSV import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,18 @@ $ echo "{ \"username\" : \"dzello\", \"city\": \"San Francisco\" }" | keen event
 # { "username" : "dzello", "city" : "San Francisco" }
 # { "username" : "KarlTheFog", "city" : "San Francisco" }
 # { "username" : "polarvortex", "city" : "Chicago" }
-$ keen events:add --file events.json
+$ keen events:add -c signups --file events.json
 
 # add events from a file that contains an array of JSON objects
 # [{ "apple" : "sauce" }, { "banana" : "pudding" }, { "cherry" : "pie" }]
-$ keen events:add --file events.json
+$ keen events:add -c signups --file events.json
 
 # add events from a file in CSV format. the first row must be column names:
 # username, city
 # dzello, San Francisco
 # KarlTheFog, San Francisco
 # polarvortex, Chicago
-$ keen events:add --file events.csv --csv
+$ keen events:add -c signups --file events.csv --csv
 ```
 
 Notes:


### PR DESCRIPTION
The import-from-file examples don't include a collection name. If you're smart you can look above and assume that the collection name is set using an environment variable, but some people may scroll down to the CSV import method and won't get that context.

This change sets the collection name more explicitly and makes it more clear that when you import events from CSV, that CSV should only contain one type of event (at first reading of current docs, I thought maybe there was a way to set a column for collection name in the CSV, and that's why it wasn't included as a parameter in the import command - that's not the case though).
