### PR TITLE
Location coordinates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rspec/core/rake_task'
 
 desc "Run Rspec unit tests"
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = "spec/aud/**/*_spec.rb"
+  t.pattern = "spec/keen-cli/**/*_spec.rb"
 end
 
 task :default => :spec

--- a/keen-cli.gemspec
+++ b/keen-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'debugger'
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'webmock'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/keen-cli/batch_processor.rb
+++ b/lib/keen-cli/batch_processor.rb
@@ -93,6 +93,17 @@ module KeenCli
         keen.delete("created_at")
       end
 
+      # Set the keen.location.coordinates to a true array
+      if event["keen"] and event["keen"]["location"] and event["keen"]["location"]["coordinates"]
+        coordinates = event["keen"]["location"]["coordinates"]
+
+        if coordinates and coordinates[0] == "[" and coordinates[coordinates.length-1] == "]"
+          event["keen"]["location"]["coordinates"] = coordinates[1..coordinates.length-2].split(',').map(&:to_f)
+        elsif coordinates.class != Array # This should never happen, but just in case..
+          event["keen"].delete("location")
+        end
+      end
+
       self.events.push(event)
       self.size += 1
       self.total_size += 1

--- a/lib/keen-cli/version.rb
+++ b/lib/keen-cli/version.rb
@@ -1,3 +1,3 @@
 module KeenCli
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/keen-cli/batch_processor_spec.rb
+++ b/spec/keen-cli/batch_processor_spec.rb
@@ -166,6 +166,11 @@ module KeenCli
         expect(batch_processor.events.first).to eq({ "keen" => {} })
       end
 
+      it 'reformats the keen.location.coordinates property' do
+        batch_processor.add('{ "keen": { "location": { "coordinates": "[12.12, 34.34]" } } }')
+        expect(batch_processor.events.first).to eq({"keen" => { "location" => { "coordinates" => [12.12, 34.34] } } })
+      end
+
     end
 
     describe 'flush' do


### PR DESCRIPTION
This PR reformats `keen.location.coordinates` properties that are currently strings in to proper arrays. This issue primarily arises from doing extractions and then reuploading the data - extractions (and all CSVs) will represent the array as a string like `"[12.12, 34.34]"`.

A few other items to note:

- I had to remove the `debugger` dependency and upgrade to `byebug`. `debugger` is no longer support in Ruby 2.x
- If the `keen.location.coordinates` property is not an array AND is malformed, I just delete `keen.location`